### PR TITLE
Bump logback-version from 1.2.10 to 1.2.11 (#2868)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -96,7 +96,7 @@
 			ch.qos.logback:logback-classic and logback-core is shared with
 				- net.pms:ums
 		-->
-		<logback-version>1.2.10</logback-version>
+		<logback-version>1.2.11</logback-version>
 		<surefire-version>3.0.0-M5</surefire-version>
 
 		<!--


### PR DESCRIPTION
Bumps `logback-version` from 1.2.10 to 1.2.11.

Updates `logback-classic` from 1.2.10 to 1.2.11

Updates `logback-core` from 1.2.10 to 1.2.11

---
updated-dependencies:
- dependency-name: ch.qos.logback:logback-classic
  dependency-type: direct:production
  update-type: version-update:semver-patch
- dependency-name: ch.qos.logback:logback-core
  dependency-type: direct:production
  update-type: version-update:semver-patch
...

Signed-off-by: dependabot[bot] <support@github.com>

Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>